### PR TITLE
Issue33

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 Trilium Notes is an Evernote-like hierarchical note taking application with many advanced features, focused on building a large personal knowledge base.
 
 
-**Shipped version:** 0.57.5~ynh1
+**Shipped version:** 0.57.5~ynh2
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -18,7 +18,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 Trilium Notes est une application de prise de note hiérarchique semblable a Evernote, avec maintes fonctions avancées, centrée sur la construction d'une large base de connaissances personnelle.
 
 
-**Version incluse :** 0.57.5~ynh1
+**Version incluse :** 0.57.5~ynh2
 
 ## Captures d'écran
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "A hierarchical note taking application with focus on building large personal knowledge base",
         "fr": "Une application de prise de note hiérarchique centrée sur la construction d'une large base de connaissances personnelle"
     },
-    "version": "0.57.5~ynh1",
+    "version": "0.57.5~ynh2",
     "url": "https://github.com/zadam/trilium",
     "upstream": {
         "license": "AGPL-3.0-only",

--- a/scripts/backup
+++ b/scripts/backup
@@ -46,7 +46,7 @@ ynh_backup --src_path="$final_path"
 # BACKUP THE DATA DIR
 #=================================================
 
-ynh_backup --src_path="$datadir" --is_big
+ynh_backup --src_path="$datadir"
 
 #=================================================
 # BACKUP THE NGINX CONFIGURATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -66,7 +66,7 @@ chown -R $app:www-data "$final_path"
 #=================================================
 ynh_script_progression --message="Restoring the data directory..."
 
-ynh_restore_file --origin_path="$datadir" --not_mandatory
+ynh_restore_file --origin_path="$datadir"
 
 mkdir -p $datadir
 


### PR DESCRIPTION
## Problem

- Fix issue 33. Data dir not backed up on pre-upgrade backup. When trying my upgrade to v0.58.4 branch, I discovered that the data directory isn't backed up with the app. Since this version upgrade includes a database change it breaks backward compatibility.

## Solution

- Removed the optional backup flags from the scripts.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
