### PR TITLE
Allow path installation

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,7 +1,7 @@
 #sub_path_only rewrite ^__PATH__$ __PATH__/ permanent;
 location __PATH__/ {
 
-  proxy_pass        http://127.0.0.1:__PORT__;
+  proxy_pass        http://127.0.0.1:__PORT__/;
   proxy_redirect    off;
   proxy_set_header  Host $host;
   proxy_set_header  X-Real-IP $remote_addr;

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -13,6 +13,7 @@ Environment=NODE_ENV=production
 Environment=TRILIUM_ENV=dev
 WorkingDirectory=__INSTALL_DIR__/
 ExecStart=__YNH_NODE__ __INSTALL_DIR__/src/www
+Restart=always
 
 
 # Sandboxing options to harden security

--- a/manifest.toml
+++ b/manifest.toml
@@ -29,7 +29,10 @@ ram.runtime = "110M"
 [install]
     [install.domain]
     type = "domain"
-    full_domain = true
+
+    [install.path]
+    type = "path"
+    default = "/trilium"
 
     [install.init_main_permission]
     help.en = "Enabling visitors access is required for sync with desktop app"


### PR DESCRIPTION
## Problem

- *Currently installation is only possible on a full domain name. This is an unnecessary limitation.*

## Solution

- *Allow installation on sub path, as it works perfectly well.*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
